### PR TITLE
Fix many:many .has() utility

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1414,7 +1414,7 @@ class PromiseEdgeOrNullImpl<
     if (sourceId === null) {
       return null;
     }
-    const edgeDoc = this.ctx.db
+    const edgeDoc = await this.ctx.db
       .query(this.edgeDefinition.table)
       .withIndex(edgeCompoundIndexName(this.edgeDefinition), (q) =>
         (q.eq(this.edgeDefinition.field, sourceId as any) as any).eq(


### PR DESCRIPTION
This utility always returns `true`. There was a missing `await` which means `Promise { <pending> } !== null` will always be true.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.